### PR TITLE
Fix UTC conversion bug with event dates

### DIFF
--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -2,6 +2,7 @@ import React from 'react'
 import styled from '@emotion/styled'
 import { Link } from 'gatsby'
 import Img from 'gatsby-image'
+import moment from 'moment'
 
 const Post = styled.li`
   position: relative;
@@ -65,9 +66,11 @@ const Excerpt = styled.p`
 `
 
 const Card = ({ slug, heroImage, title, ...props }) => {
-  const cardDate = props.publishDate || props.eventStartDate
-  const cardEndDate = props.eventEndDate
+  const cardDate = moment(props.publishDate || props.eventStartDate).format("MMMM DD, YYYY h:mmA")
+  const cardEndDate = props.eventEndDate ? moment(props.eventEndDate).format("h:mmA") : null
+
   const mainText = props.body || props.description
+
   return (
     <>
       {heroImage && mainText && (

--- a/src/templates/events.js
+++ b/src/templates/events.js
@@ -71,8 +71,8 @@ export const query = graphql`
               src
             }
           }
-          eventStartDate(formatString: "MMMM DD, YYYY h:mmA")
-          eventEndDate(formatString: "h:mmA")
+          eventStartDate
+          eventEndDate
           eventUrl
           description {
             childMarkdownRemark {


### PR DESCRIPTION
@vishalbakshi noticed that events on the events page were displaying in UTC. Turns out gatsby uses moment.js to parse dates but doesn't let us configure outputting as local vs UTC, so let's just use moment directly