### PR TITLE
eventPageDisplay

### DIFF
--- a/src/components/PostDetails.js
+++ b/src/components/PostDetails.js
@@ -17,8 +17,9 @@ const ReadingTime = styled.p`
   display: inline-block;
 `
 
-const Url = styled.h3`
+const Url = styled.a`
   margin: 1rem 1rem 0 1rem;
+  text-decoration: none;
   color: gray;
 `
 
@@ -26,9 +27,9 @@ const PostDetails = props => {
   return (
     <Wrapper>
       <Date>📅 {props.date}</Date>
-      <span>•</span>
-      <ReadingTime>{`⏱️${props.timeToRead} min read `}</ReadingTime>
-      {props.url && <Url>{props.url}</Url>}
+      {props.timeToRead && <span>•</span>}
+      {props.timeToRead && <ReadingTime>{`⏱️${props.timeToRead} min read `}</ReadingTime>}
+      {props.url && <Url href={props.url}>{props.url}</Url>}
     </Wrapper>
   )
 }

--- a/src/templates/event.js
+++ b/src/templates/event.js
@@ -48,7 +48,6 @@ const EventTemplate = ({ data, pageContext }) => {
         <PostDetails
           date={eventStartDate}
           url={eventUrl}
-          timeToRead={description.childMarkdownRemark.timeToRead}
         />
         <PageBody body={description} />
       </Container>

--- a/src/templates/event.js
+++ b/src/templates/event.js
@@ -8,6 +8,7 @@ import TagList from '../components/TagList'
 import PostLinks from '../components/PostLinks'
 import PostDetails from '../components/PostDetails'
 import SEO from '../components/SEO'
+import moment from 'moment'
 
 const EventTemplate = ({ data, pageContext }) => {
   const {
@@ -23,6 +24,7 @@ const EventTemplate = ({ data, pageContext }) => {
   const previous = pageContext.prev
   const next = pageContext.next
   const { basePath } = pageContext
+  const eventDateLocalTime = moment(eventStartDate).format("MMMM DD, YYYY h:mmA")
 
   let ogImage
   try {
@@ -46,7 +48,7 @@ const EventTemplate = ({ data, pageContext }) => {
       <Container>
         {tags && <TagList tags={tags} basePath={basePath} />}
         <PostDetails
-          date={eventStartDate}
+          date={eventDateLocalTime}
           url={eventUrl}
         />
         <PageBody body={description} />
@@ -66,8 +68,7 @@ export const query = graphql`
           content
         }
       }
-      eventStartDate(formatString: "MMMM DD, YYYY h:mmA")
-      eventStartDateISO: eventStartDate(formatString: "YYYY-MM-DD")
+      eventStartDate
       eventEndDate(formatString: "h:mmA")
       eventUrl
       heroImage {


### PR DESCRIPTION
Fix variety of event page display issues:
- event times now in local, not UTC
- event URLs now clickable
- no "time to read" for events