### PR TITLE
Minor titling fixes

### DIFF
--- a/src/templates/events.js
+++ b/src/templates/events.js
@@ -29,9 +29,9 @@ const Events = ({ data, pageContext }) => {
 
   return (
     <Layout>
-      <PageTitle>Events</PageTitle>
       <SEO title={startCase(basePath)} image={ogImage} />
       <Container>
+        <PageTitle>Events</PageTitle>
         {isFirstPage ? (
           <CardList>
             <Card {...featuredEvent} featured basePath={basePath} />

--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -3,6 +3,7 @@ import { graphql } from 'gatsby'
 import Layout from '../components/Layout'
 import Container from '../components/Container'
 import PageBody from '../components/PageBody'
+import PageTitle from '../components/PageTitle'
 import SEO from '../components/SEO'
 
 const PageTemplate = ({ data, pageContext }) => {
@@ -18,6 +19,7 @@ const PageTemplate = ({ data, pageContext }) => {
         }
       />
       <Container>
+        <PageTitle>{title}</PageTitle>
         <PageBody body={body} />
       </Container>
     </Layout>


### PR DESCRIPTION
Move events page title to inside page content (was previously outside the main styling element `Container`)

Add page title to pages generated by contentful